### PR TITLE
Mustafa/bump build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymarket/order-utils",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Typescript utility for creating orders for Polymarket's CLOB",
   "author": "Liam Kovatch <liam@polymarket.com>",
   "homepage": "https://github.com/Polymarket/clob-order-utils",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "build": "make build",
     "test": "make test",
     "lint": "make lint",
-    "postbuild": "cp package.json dist && cp README.md dist"
+    "postbuild": "cp package.json dist && cp README.md dist",
+    "prepublishOnly": "make build"
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.2",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps to 3.0.1 and adds a prepublish build step to the package scripts.
> 
> - **Release/Packaging**:
>   - Bump `version` to `3.0.1` in `package.json`.
>   - Add `prepublishOnly` script to run `make build` before publishing.
>   - Update `scripts` block formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b42e60b4aa3a94538f24c0544b9fa571e66279a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->