### PR TITLE
Add CLI example for creating and signing CLOB orders

### DIFF
--- a/examples/create-order.ts
+++ b/examples/create-order.ts
@@ -1,0 +1,44 @@
+import "dotenv/config";
+
+import { createLimitOrder, signOrder } from "../src"; // если нужно, изменим путь
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`[clob-order-utils] Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+async function main() {
+  const privateKey = requireEnv("PRIVATE_KEY");
+  const exchangeAddress = requireEnv("EXCHANGE_ADDRESS");
+  const chainIdRaw = requireEnv("CHAIN_ID");
+
+  const chainId = Number(chainIdRaw);
+  if (!Number.isFinite(chainId)) {
+    console.error(
+      `[clob-order-utils] Invalid CHAIN_ID, expected number, got: ${chainIdRaw}`,
+    );
+    process.exit(1);
+  }
+
+  const order = createLimitOrder({
+    marketId: "MARKET_ID_HERE",
+    outcome: 0,
+    price: "0.5",
+    size: "1",
+    side: "buy",
+    maker: exchangeAddress,
+    chainId,
+  });
+
+  const signed = await signOrder(order, privateKey);
+  console.log(JSON.stringify(signed, null, 2));
+}
+
+main().catch((err) => {
+  console.error("[clob-order-utils] Unexpected error:", err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "build": "make build",
     "test": "make test",
     "lint": "make lint",
-    "postbuild": "cp package.json dist && cp README.md dist"
+    "postbuild": "cp package.json dist && cp README.md dist",
+    "example:create-order": "ts-node examples/create-order.ts"
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.2",


### PR DESCRIPTION
Adds a small CLI-style example that:
- reads config from `PRIVATE_KEY`, `EXCHANGE_ADDRESS` and `CHAIN_ID`,
- creates and signs a single limit order,
- prints the signed order JSON.

Includes an npm script:
`npm run example:create-order`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CLI-style example (`examples/create-order.ts`) and npm script to create and sign a limit order from env vars and print the signed JSON.
> 
> - **Examples**:
>   - Add `examples/create-order.ts` that reads `PRIVATE_KEY`, `EXCHANGE_ADDRESS`, and `CHAIN_ID`, validates `CHAIN_ID`, creates a limit order via `createLimitOrder`, signs it with `signOrder`, and prints the signed JSON.
> - **Scripts**:
>   - Add `npm run example:create-order` to execute the example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3370ca1cc9bafd6bb8bce4851f5a01b460f327f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->